### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,4 +608,4 @@ If you find this repository useful, please consider citing:
 
 <!-- ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=BaiShuanghao/Awesome-Robotics-Manipulation&type=date&legend=top-left)](https://www.star-history.com/#BaiShuanghao/Awesome-Robotics-Manipulation&type=date&legend=top-left) -->
+[![Star History Chart](https://star-history.dera.page/svg?repos=BaiShuanghao/Awesome-Robotics-Manipulation&type=date&legend=top-left)](https://star-history.dera.page/#BaiShuanghao/Awesome-Robotics-Manipulation&type=date&legend=top-left) -->


### PR DESCRIPTION
This fixes the broken star history chart. The GitHub stargazer API is rate-limited so the chart no longer renders. Switched both the chart image (svg) and the wrapping link to the new star-history.dera.page domain, which needs no API token and serves the SVG and frontend on the same host.

The change is scoped to the already-commented-out ## Star History block in README.md (one line). No badge endpoint was touched.

References: Mubelotix/star-history fork and prior PRs removing api.star-history.com references.